### PR TITLE
sets minimum distance to 0 to allow no-distance activities

### DIFF
--- a/server/deimos/src/components/AddActivityForm/AddActivityForm.jsx
+++ b/server/deimos/src/components/AddActivityForm/AddActivityForm.jsx
@@ -107,7 +107,7 @@ export default function AddActivityForm({
         {/* ============= DISTANCE ============= */}
         <Item label="Distance" className="distance-wrapper">
           <Item name="distance" className="inline-item">
-            <InputNumber precision={2} min={0.1} step={0.1} placeholder={5} />
+            <InputNumber precision={2} min={0.0} step={0.1} placeholder={5} />
           </Item>
           <Item name="unit" className="unit inline-item">
             <Select>


### PR DESCRIPTION
Fixes two bugs:
1. If distance is accidentally incremented for a no-distance activity (like yoga), it can't be decremented back to 0
2. If an activity with 0 distance is added to quick-add, it sets the distance to 0.1 on add